### PR TITLE
Updated object-assign dependency #7

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "babel-preset-es2015": "6.3.13",
     "error.js": "^1.2.1",
     "request": "2.69.0",
+    "object-assign": "4.0.1",
     "urijs": "1.17.0"
   },
   "devDependencies": {
@@ -48,7 +49,6 @@
     "karma-phantomjs-launcher": "1.0.0",
     "karma-sauce-launcher": "0.3.0",
     "mocha": "2.4.5",
-    "object-assign": "4.0.1",
     "phantomjs-prebuilt": "2.1.3",
     "watchify": "3.7.0"
   }


### PR DESCRIPTION
Because object-assign is not only used in testings, we needed to move it to dependency